### PR TITLE
Feature/multiple inputs

### DIFF
--- a/data/preprocess.py
+++ b/data/preprocess.py
@@ -21,8 +21,7 @@ class BasePreprocessor(object):
     def __init__(self, word_mapping=None, char_mapping=None,
                  part_of_speech_mapping=None, omit_labels=None,
                  max_words=(33, 20), chars_per_word=13,
-                 include_word_vectors=True, include_chars=True, include_pos_tags=True,
-                 include_amr_path=False, include_sdg_path=False, include_interaction_tuple=False):
+                 include_word_vectors=True, include_chars=True, include_pos_tags=True):
         self.word_mapping = word_mapping
         self.char_mapping = char_mapping
         self.part_of_speech_mapping = part_of_speech_mapping
@@ -34,10 +33,6 @@ class BasePreprocessor(object):
         self.include_word_vectors = include_word_vectors
         self.include_chars = include_chars
         self.include_pos_tags = include_pos_tags
-
-        self.include_interaction_tuple = include_interaction_tuple
-        self.include_amr_path = include_amr_path
-        self.include_sdg_path = include_sdg_path
 
     @staticmethod
     def load_data(file_path):
@@ -139,9 +134,14 @@ class BasePreprocessor(object):
 
 class BioNLPPreprocessor(BasePreprocessor):
 
-    def __init__(self, omit_interactions=None, include_single_interaction=True, **kwargs):
+    def __init__(self, omit_interactions=None, include_single_interaction=True,
+                 include_amr_path=False, include_sdg_path=False, include_interaction_tuple=False, **kwargs):
         self.valid_interactions = omit_interactions
         self.include_single_interaction = include_single_interaction
+
+        self.include_interaction_tuple = include_interaction_tuple
+        self.include_amr_path = include_amr_path
+        self.include_sdg_path = include_sdg_path
         super(BioNLPPreprocessor, self).__init__(**kwargs)
 
     @staticmethod
@@ -170,17 +170,9 @@ class BioNLPPreprocessor(BasePreprocessor):
 
         res = [text]
         if self.include_interaction_tuple:      res.append(' '.join(interaction_tuple))
-        if self.include_amr_path:               res.append(self.get_amr_path(sample=sample))
-        if self.include_sdg_path:               res.append(self.get_sdg_path(sample=sample))
+        if self.include_amr_path:               res.append(sample['amr_path'])
+        if self.include_sdg_path:               res.append(sample['sdg_path'])
         return tuple(res)
-
-    @staticmethod
-    def get_amr_path(sample):
-        return sample['amr_path']
-
-    @staticmethod
-    def get_sdg_path(sample):
-        return sample['sdg_path']
 
     def get_label(self, sample):
         return sample['label']

--- a/data/preprocess.py
+++ b/data/preprocess.py
@@ -20,23 +20,22 @@ def pad(x, max_len):
 class BasePreprocessor(object):
     def __init__(self, word_mapping=None, char_mapping=None,
                  part_of_speech_mapping=None, omit_labels=None,
-                 max_words_p=33, max_words_h=20, chars_per_word=13,
-                 include_word_vectors=True, include_chars=True,
-                 include_pos_tags=True, include_exact_match=True,
-                 include_amr_path=False, include_sdg_path=False):
+                 max_words=(33, 20), chars_per_word=13,
+                 include_word_vectors=True, include_chars=True, include_pos_tags=True,
+                 include_amr_path=False, include_sdg_path=False, include_interaction_tuple=False):
         self.word_mapping = word_mapping
         self.char_mapping = char_mapping
         self.part_of_speech_mapping = part_of_speech_mapping
         self.omit_labels = omit_labels if omit_labels is not None else set()
 
-        self.max_words_p = max_words_p
-        self.max_words_h = max_words_h
+        self.max_words = max_words
         self.chars_per_word = chars_per_word
 
         self.include_word_vectors = include_word_vectors
         self.include_chars = include_chars
         self.include_pos_tags = include_pos_tags
-        self.include_exact_match = include_exact_match
+
+        self.include_interaction_tuple = include_interaction_tuple
         self.include_amr_path = include_amr_path
         self.include_sdg_path = include_sdg_path
 
@@ -60,11 +59,11 @@ class BasePreprocessor(object):
             data = self.load_data(file_path=file_path)
 
             for sample in tqdm(data):
-                premise, hypothesis = self.get_sentences(sample)
-                premise_words,    premise_speech    = self.get_words_with_part_of_speech(sample, premise)
-                hypothesis_words, hypothesis_speech = self.get_words_with_part_of_speech(sample, hypothesis)
-                all_words           += premise_words  + hypothesis_words
-                all_parts_of_speech += premise_speech + hypothesis_speech
+                sentences = self.get_sentences(sample)
+                for sentence in sentences:
+                    words, part_of_speech = self.get_words_with_part_of_speech(sample, sentence)
+                    all_words += words
+                    all_parts_of_speech += part_of_speech
 
         return all_words, all_parts_of_speech
 
@@ -74,12 +73,6 @@ class BasePreprocessor(object):
     def get_labels(self):
         raise NotImplementedError
 
-    def get_amr_path(self, sample):
-        return None
-
-    def get_sdg_path(self, sample):
-        return None
-
     def label_to_one_hot(self, label):
         label_set = self.get_labels()
         res = np.zeros(shape=(len(label_set)), dtype=np.bool)
@@ -88,89 +81,50 @@ class BasePreprocessor(object):
         return res
 
     def parse_sentence(self, sample, sentence, max_words, chars_per_word):
-        # Words
         words, parts_of_speech = self.get_words_with_part_of_speech(sample, sentence)
-        word_ids = [self.word_mapping[word] for word in words]
 
-        # Syntactical features
-        pos_tag_ids = [self.part_of_speech_mapping[part] for part in parts_of_speech]
+        word_ids = [self.word_mapping[word] for word in words]                          # Words
+        pos_tag_ids = [self.part_of_speech_mapping[part] for part in parts_of_speech]   # Syntactical features
+        char_ids = [[self.char_mapping[c] for c in word] for word in words]             # Chars
+        char_ids = pad_sequences(char_ids, maxlen=chars_per_word, padding='post', truncating='post')
 
-        # Chars
-        chars = [[self.char_mapping[c] for c in word] for word in words]
-        chars = pad_sequences(chars, maxlen=chars_per_word, padding='post', truncating='post')
+        res = []
+        if self.include_word_vectors:   res.append(np.array(word_ids))
+        if self.include_pos_tags:       res.append(np.array(pos_tag_ids))
+        if self.include_chars:          res.append(np.array(pad(char_ids, max_words)))
+        return tuple(res)
 
-        return (words, parts_of_speech, np.array(word_ids, copy=False),
-                pos_tag_ids,
-                pad(chars, max_words))
-
-    def parse_one(self, sample, premise, hypothesis, max_words_p, max_words_h, chars_per_word):
-        (premise_words, premise_parts_of_speech, premise_word_ids,
-         premise_syntactical_ids, premise_chars) = self.parse_sentence(sentence=premise, sample=sample, max_words=max_words_p, chars_per_word=chars_per_word)
-
-        (hypothesis_words, hypothesis_parts_of_speech, hypothesis_word_ids,
-         hypothesis_syntactical_ids, hypothesis_chars) = self.parse_sentence(sentence=hypothesis, sample=sample, max_words=max_words_h, chars_per_word=chars_per_word)
-
-        def calculate_exact_match(source_words, target_words):
-            source_words = [word.lower() for word in source_words]
-            target_words = [word.lower() for word in target_words]
-            target_words = set(target_words)
-
-            res = [(word in target_words) for word in source_words]
-            return np.array(res)
-
-        premise_exact_match    = calculate_exact_match(premise_words, hypothesis_words)
-        hypothesis_exact_match = calculate_exact_match(hypothesis_words, premise_words)
-
-        return (premise_word_ids, hypothesis_word_ids,
-                premise_chars, hypothesis_chars,
-                premise_syntactical_ids, hypothesis_syntactical_ids,
-                premise_exact_match, hypothesis_exact_match)
+    def parse_one(self, sample, sentences, max_words, chars_per_word):
+        """ :return: [ (word_ids, pos_tag_ids, char_ids) for sentence in sentences ] """
+        return [self.parse_sentence(sample=sample, sentence=sentence,
+                                    max_words=max_w, chars_per_word=chars_per_word)
+                for sentence, max_w in zip(sentences, max_words)]
 
     def parse(self, data, verbose=False):
-        # res = [premise_word_ids, hypothesis_word_ids, premise_chars, hypothesis_chars,
-        # premise_pos_tag_ids, hypothesis_pos_tag_ids, premise_exact_match, hypothesis_exact_match]
-        res = [[], [], [], [], [], [], [], [], []]
-
+        """ :return: [word_ids..., pos_tag_ids..., char_ids...] """
+        res = []
         for sample in tqdm(data) if verbose else data:
             if self.skip_sample(sample=sample):
                 continue
+
             label = self.get_label(sample=sample)
-            premise, hypothesis = self.get_sentences(sample=sample)
-
-            if self.include_amr_path:
-                ''' Add AMR path to hypothesis '''
-
-                # TODO: Implement an option for using both amr and sdg paths
-                if self.include_sdg_path:
-                    raise NotImplementedError("Using both SDG and AMR paths is not implemented yet")
-                hypothesis = self.get_amr_path(sample)
-
-            elif self.include_sdg_path:
-                ''' Add SDG path to hypothesis '''
-                hypothesis = self.get_sdg_path(sample)
-
-            sample_inputs = self.parse_one(sample=sample, premise=premise, hypothesis=hypothesis,
-                                           max_words_h=self.max_words_h, max_words_p=self.max_words_p,
-                                           chars_per_word=self.chars_per_word)
+            sentences = self.get_sentences(sample=sample)
+            sample_inputs = self.parse_one(sample=sample, sentences=sentences,
+                                           max_words=self.max_words, chars_per_word=self.chars_per_word)
             label = self.label_to_one_hot(label=label)
 
-            sample_result = list(sample_inputs) + [label]
-            for res_item, parsed_item in zip(res, sample_result):
-                res_item.append(parsed_item)
+            sample_result = []
+            for j in range(len(sample_inputs[0])):
+                for i in range(len(sample_inputs)):
+                    sample_result.append(sample_inputs[i][j])
+            sample_result.append(label)
+            res.append(sample_result)
 
-        res[0] = pad_sequences(res[0], maxlen=self.max_words_p, padding='post', truncating='post', value=0.)  # input_word_p
-        res[1] = pad_sequences(res[1], maxlen=self.max_words_h, padding='post', truncating='post', value=0.)  # input_word_h
-        res[4] = pad_sequences(res[4], maxlen=self.max_words_p, padding='post', truncating='post', value=0.)  # pos_tag_p
-        res[5] = pad_sequences(res[5], maxlen=self.max_words_h, padding='post', truncating='post', value=0.)  # pos_tag_h
-        res[6] = pad_sequences(res[6], maxlen=self.max_words_p, padding='post', truncating='post', value=0.)  # exact_match_p
-        res[7] = pad_sequences(res[7], maxlen=self.max_words_h, padding='post', truncating='post', value=0.)  # exact_match_h
-
-        # Determine which part of data we need to dump
-        if not self.include_exact_match:             del res[6:8]  # Exact match feature
-        if not self.include_pos_tags:                del res[4:6]  # Syntactical POS tags
-        if not self.include_chars:                   del res[2:4]  # Character features
-        if not self.include_word_vectors:            del res[0:2]  # Word vectors
-        return [np.array(item) for item in res]
+        res = list(zip(*res))
+        for i in range(len(res) - 1):
+            res[i] = pad_sequences(res[i], maxlen=self.max_words[i % len(self.max_words)], padding='post', truncating='post')
+        res[-1] = np.array(res[-1])
+        return res
 
     def parse_file(self, input_file_path):
         data = self.load_data(input_file_path)
@@ -213,21 +167,20 @@ class BioNLPPreprocessor(BasePreprocessor):
         text = ' '.join(sample['tokenized_text']) if 'tokenized_text' in sample else sample['text']
         interaction_tuple = sample['interaction_tuple']
         interaction_tuple = [item for item in interaction_tuple if item is not None]
-        return text, ' '.join(interaction_tuple)
 
-    def get_amr_path(self, sample):
-        if sample['amr_path'].strip() != '':
-            return sample['amr_path']
-        interaction_tuple = sample['interaction_tuple']
-        interaction_tuple = [item for item in interaction_tuple if item is not None]
-        return ' '.join(interaction_tuple)
+        res = [text]
+        if self.include_interaction_tuple:      res.append(' '.join(interaction_tuple))
+        if self.include_amr_path:               res.append(self.get_amr_path(sample=sample))
+        if self.include_sdg_path:               res.append(self.get_sdg_path(sample=sample))
+        return tuple(res)
 
-    def get_sdg_path(self, sample):
-        if sample['sdg_path'].strip() != '':
-            return sample['sdg_path']
-        interaction_tuple = sample['interaction_tuple']
-        interaction_tuple = [item for item in interaction_tuple if item is not None]
-        return ' '.join(interaction_tuple)
+    @staticmethod
+    def get_amr_path(sample):
+        return sample['amr_path']
+
+    @staticmethod
+    def get_sdg_path(sample):
+        return sample['sdg_path']
 
     def get_label(self, sample):
         return sample['label']

--- a/model/architectures.py
+++ b/model/architectures.py
@@ -35,7 +35,7 @@ class Classifier(Model):
         self.nb_pos_tags = nb_pos_tags
 
         inputs, embeddings = self.create_inputs()
-        embeddings = [Concatenate()(embedding) for embedding in embeddings]
+        embeddings = [Concatenate()(list(embedding)) for embedding in embeddings]
 
         encodings = self.create_encodings(embeddings)
         interaction = self.create_interaction(encodings)
@@ -57,12 +57,12 @@ class Classifier(Model):
                                                self.include_pos_tag_features,
                                                self.include_chars]) if include]
         inputs = []
-        embeddings = [[], []]
+        embeddings = [[] for _ in range(len(self.input_shapes))]
         for create_input in creators:
             net_inputs, net_embeddings = create_input()
             inputs += net_inputs
-            embeddings[0].append(net_embeddings[0])
-            embeddings[1].append(net_embeddings[1])
+            for i in range(len(net_embeddings)):
+                embeddings[i].append(net_embeddings[i])
 
         return inputs, embeddings
 

--- a/model/architectures.py
+++ b/model/architectures.py
@@ -35,7 +35,7 @@ class Classifier(Model):
         self.nb_pos_tags = nb_pos_tags
 
         inputs, embeddings = self.create_inputs()
-        embeddings = [Concatenate()(list(embedding)) for embedding in embeddings]
+        embeddings = [Concatenate()(embedding) if len(embedding) > 1 else embedding for embedding in embeddings]
 
         encodings = self.create_encodings(embeddings)
         interaction = self.create_interaction(encodings)
@@ -88,7 +88,7 @@ class BiGRUClassifier(Classifier):
                                   dropout=self.dropout_rate))(embedding) for embedding in embeddings]
 
     def create_interaction(self, encodings):
-        concat = Concatenate(axis=1)(encodings)
+        concat = Concatenate(axis=1)(encodings) if len(encodings) > 1 else encodings
         interaction = Bidirectional(GRU(units=128, dropout=self.dropout_rate))(concat)
         return interaction
 

--- a/model/architectures.py
+++ b/model/architectures.py
@@ -8,7 +8,7 @@ from feature_extractors.densenet import DenseNet
 from layers.decaying_dropout import DecayingDropout
 from layers.encoding import Encoding
 from layers.interaction import Interaction
-from model.input import WordVectorInput, CharInput, PosTagInput, ExactMatchInput
+from model.input import WordVectorInput, CharInput, PosTagInput
 from optimizers.l2optimizer import L2Optimizer
 
 
@@ -17,7 +17,6 @@ class Classifier(Model):
                  include_word_vectors=True, word_embedding_weights=None, train_word_embeddings=True,
                  include_chars=True, chars_per_word=16, char_embedding_size=8,
                  include_pos_tag_features=True, nb_pos_tags=20, pos_tag_embedding_size=8,
-                 include_exact_match=True,
                  nb_labels=3,
                  inputs=None, outputs=None, name='RelationClassifier'):
         if inputs or outputs:
@@ -34,7 +33,6 @@ class Classifier(Model):
         self.include_pos_tag_features = include_pos_tag_features
         self.pos_tag_embedding_size = pos_tag_embedding_size
         self.nb_pos_tags = nb_pos_tags
-        self.include_exact_match = include_exact_match
 
         inputs, embeddings = self.create_inputs()
         embeddings = [Concatenate()(embedding) for embedding in embeddings]
@@ -49,17 +47,15 @@ class Classifier(Model):
         creators = [f for (f, include) in zip([WordVectorInput(shapes=self.input_shapes,
                                                                word_embedding_weights=self.word_embedding_weights,
                                                                train_word_embeddings=self.train_word_embeddings),
-                                               CharInput(shapes=self.input_shapes,
-                                                         chars_per_word=self.chars_per_word,
-                                                         embedding_size=self.char_embedding_size),
                                                PosTagInput(shapes=self.input_shapes,
                                                            nb_pos_tags=self.nb_pos_tags,
                                                            embedding_size=self.pos_tag_embedding_size),
-                                               ExactMatchInput(shapes=self.input_shapes)],
+                                               CharInput(shapes=self.input_shapes,
+                                                         chars_per_word=self.chars_per_word,
+                                                         embedding_size=self.char_embedding_size)],
                                               [self.include_word_vectors,
-                                               self.include_chars,
                                                self.include_pos_tag_features,
-                                               self.include_exact_match]) if include]
+                                               self.include_chars]) if include]
         inputs = []
         embeddings = [[], []]
         for create_input in creators:
@@ -153,7 +149,6 @@ def get_classifier(model_path=None,
                    include_word_vectors=True, word_embedding_weights=None, train_word_embeddings=True,
                    include_chars=True, chars_per_word=16, char_embedding_size=8,
                    include_pos_tag_features=True, nb_pos_tags=50, pos_tag_embedding_size=8,
-                   include_exact_match=True,
                    nb_labels=3,
                    first_scale_down_ratio=0.3, transition_scale_down_ratio=0.5, growth_rate=20,
                    layers_per_dense_block=8, nb_dense_blocks=3,
@@ -176,7 +171,6 @@ def get_classifier(model_path=None,
                                chars_per_word=chars_per_word, char_embedding_size=char_embedding_size,
                                include_pos_tag_features=include_pos_tag_features,
                                nb_pos_tags=nb_pos_tags, pos_tag_embedding_size=pos_tag_embedding_size,
-                               include_exact_match=include_exact_match,
                                dropout_rate=1.-dropout_initial_keep_rate,
                                nb_labels=nb_labels)
     elif architecture == 'DIIN':
@@ -188,7 +182,6 @@ def get_classifier(model_path=None,
                     chars_per_word=chars_per_word, char_embedding_size=char_embedding_size,
                     include_pos_tag_features=include_pos_tag_features,
                     nb_pos_tags=nb_pos_tags, pos_tag_embedding_size=pos_tag_embedding_size,
-                    include_exact_match=include_exact_match,
                     nb_labels=nb_labels,
                     first_scale_down_ratio=first_scale_down_ratio,
                     transition_scale_down_ratio=transition_scale_down_ratio,

--- a/model/input.py
+++ b/model/input.py
@@ -1,7 +1,6 @@
-from keras import backend as K
 from keras import Input, Sequential
 from keras.engine import InputLayer
-from keras.layers import Embedding, TimeDistributed, Bidirectional, GRU, Lambda
+from keras.layers import Embedding, TimeDistributed, Bidirectional, GRU
 
 
 class InputCreator(object):
@@ -66,15 +65,4 @@ class PosTagInput(InputCreator):
     def __call__(self, *args, **kwargs):
         inputs = [Input(shape=(shape,), dtype='int64') for shape in self.shapes]
         embeddings = [self.pos_tag_embedding(pos_tag_input) for pos_tag_input in inputs]
-        return inputs, embeddings
-
-
-class ExactMatchInput(InputCreator):
-    def __init__(self, shapes):
-        super(ExactMatchInput, self).__init__(shapes=shapes)
-
-    def __call__(self, *args, **kwargs):
-        expand_dim_layer = Lambda(lambda x: K.expand_dims(x, axis=-1))
-        inputs = [Input(shape=(shape,)) for shape in self.shapes]
-        embeddings = [expand_dim_layer(exact_match_input) for exact_match_input in inputs]
         return inputs, embeddings

--- a/train.py
+++ b/train.py
@@ -161,7 +161,7 @@ def train(batch_size=80, max_words=(60, 22), epochs=70, steps_per_epoch=500, pat
                                    lr_scheduler,
                                    TensorBoard(log_dir=log_dir),
                                    ModelCheckpoint(filepath=os.path.join(models_dir, 'model-{epoch:02d}-f1-{val_f1:.2f}.hdf5'), monitor='val_f1', save_best_only=True, verbose=1, mode='max'),
-                                   EarlyStopping(patience=patience)],
+                                   EarlyStopping(monitor='val_f1', patience=patience, mode='max')],
                         class_weight=class_weights)
 
 

--- a/train.py
+++ b/train.py
@@ -25,7 +25,7 @@ try:                import cPickle as pickle
 except ImportError: import _pickle as pickle
 
 
-def train(batch_size=80, p=60, h=22, epochs=70, steps_per_epoch=500, patience=5,
+def train(batch_size=80, max_words=(60, 22), epochs=70, steps_per_epoch=500, patience=5,
           chars_per_word=20, char_embed_size=8,
           pos_tag_embedding_size=8,
           l2_full_step=100000, l2_full_ratio=9e-5, l2_difference_penalty=1e-3,
@@ -43,10 +43,9 @@ def train(batch_size=80, p=60, h=22, epochs=70, steps_per_epoch=500, patience=5,
           valid_processor_load_path=None, valid_processor_save_path='data/valid_processor.pkl',
           word_vec_load_path=None, max_word_vecs=None, normalize_word_vectors=False, train_word_embeddings=False,
           dataset='bionlp',
-          train_interaction=None, valid_interaction=None,
-          omit_single_interaction=False, omit_amr_path=False, omit_sdg_path=False,
-          omit_word_vectors=False, omit_chars=False,
-          omit_pos_tags=False, omit_exact_match=False):
+          train_interaction=None, valid_interaction=None, omit_single_interaction=False,
+          omit_interaction_tuple=False, omit_amr_path=False, omit_sdg_path=False,
+          omit_word_vectors=False, omit_chars=False, omit_pos_tags=False):
 
     # Create directories if they are not present
     if not os.path.exists(models_dir):  os.mkdir(models_dir)
@@ -65,19 +64,19 @@ def train(batch_size=80, p=60, h=22, epochs=70, steps_per_epoch=500, patience=5,
     
     ''' Prepare data '''
     if dataset == 'bionlp':
-        train_processor = BioNLPPreprocessor(max_words_p=p, max_words_h=h, chars_per_word=chars_per_word,
+        train_processor = BioNLPPreprocessor(max_words=max_words, chars_per_word=chars_per_word,
                                              include_word_vectors=not omit_word_vectors,
                                              include_chars=not omit_chars,
                                              include_pos_tags=not omit_pos_tags,
-                                             include_exact_match=not omit_exact_match,
+                                             include_interaction_tuple=not omit_interaction_tuple,
                                              include_amr_path=not omit_amr_path,
                                              include_sdg_path=not omit_sdg_path,
                                              include_single_interaction=not omit_single_interaction)
-        valid_processor = BioNLPPreprocessor(max_words_p=p, max_words_h=h, chars_per_word=chars_per_word,
+        valid_processor = BioNLPPreprocessor(max_words=max_words, chars_per_word=chars_per_word,
                                              include_word_vectors=not omit_word_vectors,
                                              include_chars=not omit_chars,
                                              include_pos_tags=not omit_pos_tags,
-                                             include_exact_match=not omit_exact_match,
+                                             include_interaction_tuple=not omit_interaction_tuple,
                                              include_amr_path=not omit_amr_path,
                                              include_sdg_path=not omit_sdg_path,
                                              include_single_interaction=not omit_single_interaction)
@@ -126,7 +125,6 @@ def train(batch_size=80, p=60, h=22, epochs=70, steps_per_epoch=500, patience=5,
                            include_pos_tag_features=not omit_pos_tags,
                            nb_pos_tags=len(train_processor.part_of_speech_mapping.key_to_id),
                            pos_tag_embedding_size=pos_tag_embedding_size,
-                           include_exact_match=not omit_exact_match,
                            nb_labels=len(train_processor.get_labels()),
                            first_scale_down_ratio=first_scale_down_ratio,
                            transition_scale_down_ratio=transition_scale_down_ratio,

--- a/train.py
+++ b/train.py
@@ -115,7 +115,7 @@ def train(batch_size=80, max_words=(60, 22), epochs=70, steps_per_epoch=500, pat
 
     ''' Prepare the model '''
     model = get_classifier(architecture=architecture,
-                           input_shapes=(None, None),  # of (p, h)
+                           input_shapes=tuple([None] * len(max_words)),
                            include_word_vectors=not omit_word_vectors,
                            word_embedding_weights=train_processor.word_mapping.vectors,
                            train_word_embeddings=train_word_embeddings,


### PR DESCRIPTION
## A more generic way of giving inputs to the model
* Implemented multiple input preprocessor and made corresponding changes to model creation part
* Removed exact match feature
* Minor change: monitor f1 score instead of loss for early stopping

### API Changes
Instead of `--p --h` parameters we need to pass `--max_words` tuple which defines maximum number of words for each trunk. Now we can also have only one trunk in the model by omiting all other parameters but one and passing `--max_words 26, ` for instance.
```commandline
# Previous command line arguments
python train.py --p 26 --h 64 --batch_size 60 --omit_amr_path ...

# Current command line arguments
python train.py --max_words 26,64 --batch_size 60 --omit_interaction_tuple --omit_amr_path ...
```

Trunks come in the following order:
1. text
2. interaction_tuple
3. amr_path
4. sdg_path
